### PR TITLE
Create config file if missing

### DIFF
--- a/workon
+++ b/workon
@@ -42,6 +42,20 @@ check_for_config() {
   fi
 }
 
+usage() {
+  cat <<EOF
+Usage:  $0 add <project> <project_path>
+	     Create a project entry named <project> and edit the project script
+             in <project_path>
+        $0 edit <project>
+             Edit the project script in <project_path>
+        $0 list
+             List projects defined in $HOME/.workon
+        $0 <project>
+             Start a shell in <project>'s defined path"
+EOF
+}
+
 if [[ "$1" == "add" ]]; then
   add_project $2 $3
 elif [[ "$1" == "edit" ]]; then
@@ -50,6 +64,8 @@ elif [[ "$1" == "edit" ]]; then
 elif [[ "$1" == "list" ]]; then
   check_for_config
   list_projects
+elif [[ "$1" == "help" ]]; then
+  usage
 else
   check_for_config
   run_project $1

--- a/workon
+++ b/workon
@@ -35,12 +35,22 @@ run_project() {
   fi
 }
 
+check_for_config() {
+  if [ ! -f $HOME/.workon ]; then
+    echo "No projects configured! Add a project before use."
+    exit
+  fi
+}
+
 if [[ "$1" == "add" ]]; then
   add_project $2 $3
 elif [[ "$1" == "edit" ]]; then
+  check_for_config
   edit_project $2
 elif [[ "$1" == "list" ]]; then
+  check_for_config
   list_projects
 else
+  check_for_config
   run_project $1
 fi


### PR DESCRIPTION
Fixes #2 

Bad PR etiquette: This PR does two things.
1. It errors out if a config file doesn't exist.
2. It adds a `help` subcommand because I always have to read the source to find the options.

#### Requires a Config File
This change requires a config file for the subcommands `list`, `edit`, and running a specific project.

<img width="670" alt="image" src="https://user-images.githubusercontent.com/282048/111735053-b4ae9180-8851-11eb-96a3-1185fe7dd69a.png">

#### New Subcommand: `help`
This prints usage information. This might be better suited to checking for `--help` or `-h`, but I didn't want to get into flag parsing.

<img width="896" alt="image" src="https://user-images.githubusercontent.com/282048/111735236-0eaf5700-8852-11eb-8925-a531a72ee811.png">
