### PR TITLE
Remove the requirement to have a config file

### DIFF
--- a/workon
+++ b/workon
@@ -40,16 +40,19 @@ run_project() {
   export CURRENT_PROJECT=$1
 
   PROJECT_BASE_DIR="$PROJECT_LIST_DIR/$CURRENT_PROJECT"
-
-  if [[ -f "$PROJECT_BASE_DIR/$CONFIG_FILE_NAME" ]]; then
+  
+  if [[ -d "$PROJECT_BASE_DIR" ]]; then
     cd $PROJECT_BASE_DIR
     PROJECT_ROOT_DIR=$PROJECT_BASE_DIR
-    source $CONFIG_FILE_NAME
+
+    if [[ -f "$CONFIG_FILE_NAME" ]]; then
+      source $CONFIG_FILE_NAME
+    else
+      echo "No configuration file available. Create $PROJECT_BASE_DIR/$CONFIG_FILE_NAME if configuration is needed."
+    fi
 
     cd $PROJECT_ROOT_DIR
     exec $SHELL
-  else
-    echo "The $CURRENT_PROJECT project is not defined. Please add it first."
   fi
 }
 


### PR DESCRIPTION
It can be frustrating to have pulled down a repo and not be able to use `workon` without creating the configuration file first. This removes that requirement.

Note: This will still provide a "warning" message if the configuration file isn't present.